### PR TITLE
fix #534 Usernotes always link to submission, not to specific comment

### DIFF
--- a/modules/usernotes.js
+++ b/modules/usernotes.js
@@ -1032,7 +1032,7 @@ self._squashPermalink = function (permalink) {
         return "";
 
     // Compatibility with Sweden
-    var COMMENTS_LINK_RE = /\/comments\/(\w+)\/(?:[^\/]+\/(?:(\w+)\/)?)?/,
+    var COMMENTS_LINK_RE = /\/comments\/(\w+)\/(?:[^\/]+\/(?:(\w+)\/?)?)?/,
         MODMAIL_LINK_RE = /\/messages\/(\w+)\/?(\?.*)?$/,
 
         linkMatches = permalink.match(COMMENTS_LINK_RE),


### PR DESCRIPTION
The trailing slash in the comments link regex was non-optional. Made it optional.
